### PR TITLE
fix sticky data in buffer between clears

### DIFF
--- a/src/LoRaNow.cpp
+++ b/src/LoRaNow.cpp
@@ -389,6 +389,7 @@ void LoRaNowClass::clear()
 {
   payload_len = 0;
   payload_position = 0;
+  memset(payload_buf, 0, LORANOW_BUF_SIZE);
 }
 
 unsigned int LoRaNowClass::readInt()


### PR DESCRIPTION
Even though the size indicators for the buffers are reset to 0, data still persists in the buffer.
This has fixed some trailing 8 bytes bug for me. 